### PR TITLE
Conditional compilation for Windows Support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,13 +33,11 @@ jobs:
           mkdir C:\Cbc
           Invoke-WebRequest "https://bintray.com/coin-or/download/download_file?file_path=Cbc-2.9-win32-msvc14.zip" -OutFile "C:\Cbc\Cbc-2.9.zip"
           7z x C:\Cbc\Cbc-2.9.zip -o"C:\Cbc\"
-    - name: Build
-      run: |
           SET PATH=%PATH%;C:\Cbc\bin
           SET LIB=%LIB%;C:\Cbc\lib
+    - name: Build
+      run: |
           cargo build --verbose --all
     - name: Run tests
       run: |
-          SET PATH=%PATH%;C:\Cbc\bin
-          SET LIB=%LIB%;C:\Cbc\lib
           cargo test --verbose --all

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,4 +39,5 @@ jobs:
           cargo build --verbose --all
     - name: Run tests
       run: |
+          echo "C:\Cbc\lib" >> $GITHUB_PATH
           cargo test --verbose --all

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Prepare dependencies
       shell: powershell
-        run: |
+      run: |
           Install-Module 7Zip4PowerShell -Force -Verbose
           mkdir C:\Cbc
           Invoke-WebRequest "https://bintray.com/coin-or/download/download_file?file_path=Cbc-2.9-win32-msvc14.zip" -OutFile "C:\Cbc\Cbc-2.9.zip"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,10 +33,9 @@ jobs:
           mkdir C:\Cbc
           Invoke-WebRequest "https://bintray.com/coin-or/download/download_file?file_path=Cbc-2.9-win32-msvc14.zip" -OutFile "C:\Cbc\Cbc-2.9.zip"
           7z x C:\Cbc\Cbc-2.9.zip -o"C:\Cbc\"
-          SET PATH=%PATH%;C:\Cbc\bin
-          SET LIB=%LIB%;C:\Cbc\lib
     - name: Build
       run: |
+          echo "C:\Cbc\lib" >> $GITHUB_PATH
           cargo build --verbose --all
     - name: Run tests
       run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,3 +19,27 @@ jobs:
       run: cargo build --verbose --all
     - name: Run tests
       run: cargo test --verbose --all
+  
+  windows:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Prepare dependencies
+      shell: powershell
+        run: |
+          Install-Module 7Zip4PowerShell -Force -Verbose
+          mkdir C:\Cbc
+          Invoke-WebRequest "https://bintray.com/coin-or/download/download_file?file_path=Cbc-2.9-win32-msvc14.zip" -OutFile "C:\Cbc\Cbc-2.9.zip"
+          7z x C:\Cbc\Cbc-2.9.zip -o"C:\Cbc\"
+    - name: Build
+      run: |
+          SET PATH=%PATH%;C:\Cbc\bin
+          SET LIB=%LIB%;C:\Cbc\lib
+          cargo build --verbose --all
+    - name: Run tests
+      run: |
+          SET PATH=%PATH%;C:\Cbc\bin
+          SET LIB=%LIB%;C:\Cbc\lib
+          cargo test --verbose --all

--- a/coin_cbc_sys/src/lib.rs
+++ b/coin_cbc_sys/src/lib.rs
@@ -22,7 +22,8 @@ pub type cbc_callback = Option<
     ),
 >;
 
-#[link(name = "CbcSolver")]
+#[cfg_attr(target_os = "linux", link(name = "CbcSolver"))]
+#[cfg_attr(target_os = "windows", link(name = "libCbcSolver"))]
 extern "C" {
     pub fn Cbc_newModel() -> *mut Cbc_Model;
     pub fn Cbc_deleteModel(model: *mut Cbc_Model);

--- a/coin_cbc_sys/src/lib.rs
+++ b/coin_cbc_sys/src/lib.rs
@@ -22,8 +22,8 @@ pub type cbc_callback = Option<
     ),
 >;
 
-#[cfg_attr(target_os = "linux", link(name = "CbcSolver"))]
-#[cfg_attr(target_os = "windows", link(name = "libCbcSolver"))]
+#[cfg_attr(unix, link(name = "CbcSolver"))]
+#[cfg_attr(windows, link(name = "libCbcSolver"))]
 extern "C" {
     pub fn Cbc_newModel() -> *mut Cbc_Model;
     pub fn Cbc_deleteModel(model: *mut Cbc_Model);


### PR DESCRIPTION
### Description
The library works great in linux but failed to compile on Windows. It seems like the problem is that CbcSolver.lib is named libCbcSolver.lib in Windows (see https://github.com/jcavat/rust-lp-modeler/pull/49#issuecomment-714443545).

### Implementation
In order to provide Windows support, [conditional compilation](https://doc.rust-lang.org/reference/conditional-compilation.html) could do the trick [here](https://github.com/KardinalAI/coin_cbc/blob/master/coin_cbc_sys/src/lib.rs#L25).

It works fine in 5.9.1 with the changes, but I would need to test it in windows and see if that solves the problem (I will be able to do that maybe next week).