### PR TITLE
concurrency problem with parallel tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,7 +291,6 @@ impl Solution {
 mod test {
     use super::*;
 
-    #[test]
     fn knapsack() {
         let mut m = Model::default();
         m.set_parameter("log", "0");
@@ -325,4 +324,15 @@ mod test {
         assert_eq!(1., sol.col(cols[3]));
         assert_eq!(1., sol.col(cols[4]));
     }
+
+    #[test]
+    fn knapsack_run_1() {
+        knapsack()
+    }
+
+    #[test]
+    fn knapsack_run_2() {
+        knapsack()
+    }
+
 }


### PR DESCRIPTION
The only commit in this PR ensures that the test `knapsack()` in `src/lib.rs` is run twice. This exposes some sort of concurrency problem, that arises only sometimes. So, to trigger it, you have to run the tests a bunch of times, e.g. with this bash command:
```
S=0; F=0; for i in {1..100}; do cargo test --jobs 1 --lib knapsack; if [ $? == 0 ]; then let S+=1; else let F+=1; fi; done; echo "Successes: $S"; echo "Failures: $F"
```
(Despite the --jobs 1, module tests seem to be run in parallel, so I think the failures have something to do with two instances of some `libCbc` code running at the same time.)

I will e.g. get:
```
Successes: 86
Failures: 14
```

In addition, `Cbc` seems to sometimes switch into its command prompt mode -- this also happens with the master branch. Simply pressing enter a couple of times makes the respective test run pass, but this is obviously only possible with manual intervention and not how tests (and calls to `Cbc` in general) should work.

For both issues, I don't really have an idea why this happens. Maybe having wrapped the respective library files, someone here has an idea where this behaviour is triggered? Also, this problem might as well be a `Cbc` bug, but I wouldn't know how to easily trigger it in their test suite...