### PR TITLE
add installation infos for Cbc library dependency 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Coin CBC Rust bindings
 
-Rust bindings to the CoinOR CBC MILP Solveur using the C API.
+Rust bindings to the CoinOR CBC MILP Solver using the C API.
 
 Tested on Debian 10, AMD64, coinor-libcbc3 2.9.9+repack1-1.
+For more details on installing the `libCbc` dependencies, [see below](#prerequisites-installing-cbc-library-files).
 
 ## `coin_cbc_sys`
 
@@ -10,16 +11,33 @@ This crate exposes raw bindings to the C functions.
 
 ## `coin_cbc`
 
-This crate expose safe rust bindings using
-`coin_cbc_sys`. `coin_cbc::raw::Model` exposes direct translation of
-the C function with assert to guaranty safe use. `coin_cbc::Model`
-exposes a more user friendly, rustic and efficient API: it was used
-successfully to solve MILP with 250,000 binary variables with
-unnoticeable overhead.
+This crate exposes safe rust bindings using `coin_cbc_sys`.
+`coin_cbc::raw::Model` exposes direct translation of the C function with assert to guaranty safe use.
+`coin_cbc::Model` exposes a more user friendly, rustic and efficient API: it was used successfully to solve MILP with 250,000 binary variables with unnoticeable overhead.
 
 ## Examples
 
 See the [examples directory](examples/).
+
+## Prerequisites: installing `Cbc` library files
+
+The library files of the [`COIN-OR` Solver `Cbc`](https://github.com/coin-or/Cbc) need to present on your system when compiling a project that depends on `coin_cbc`.
+On a Debian system with a user with admin rights, this is easily achieved with:
+```
+sudo apt install coinor-libcbc-dev
+```
+
+For other systems, without admin rights or if you need a newer version of `Cbc` (e.g. with bug fixes), you can install `Cbc` through `coinbrew`:
+https://coin-or.github.io/user_introduction#building-from-source
+
+You will then have to either:
+1. register the resulting library files with your system, or 
+2. provide `cargo` with the location of that library.
+For the first option, `coinbrew` provides a command suggestion after successful compilation.
+The second option can e.g. be done via:
+```
+RUSTFLAGS='-L /path/to/your/cbc/install/lib' cargo test
+```
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,9 @@
 //! This crate exposes safe and efficient bindings to the Coin CBC C
 //! API.
 //!
+//! For more information on how to install the `Cbc` library dependencies,
+//! see [the respective README section](https://github.com/KardinalAI/coin_cbc/README.md#prerequisites-installing-cbc-library-files).
+//!
 //! This project is distributed under the MIT License by
 //! [Kardinal](https://kardinal.ai).
 


### PR DESCRIPTION
This took me quite a moment to figure out, so I'm hoping this might help others in the future.

This PR accompanies a respective docs PR over in `rust-lp-modeler`, which uses `coin_cbc`:
https://github.com/jcavat/rust-lp-modeler/pull/75