### PR TITLE
Locate cbc system library with pkg-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ On a Debian system with a user with admin rights, this is easily achieved with:
 sudo apt install coinor-libcbc-dev
 ```
 
+If you have `pkg-config` available, it'll be used to locate the library.
+
 For other systems, without admin rights or if you need a newer version of `Cbc` (e.g. with bug fixes), you can install `Cbc` through `coinbrew`:
 https://coin-or.github.io/user_introduction#building-from-source
 

--- a/coin_cbc_sys/Cargo.toml
+++ b/coin_cbc_sys/Cargo.toml
@@ -9,3 +9,6 @@ repository = "https://github.com/KardinalAI/coin_cbc"
 keywords = ["MILP", "MIP", "linear-programming"]
 categories = ["external-ffi-bindings", "mathematics", "science"]
 license = "MIT "
+
+[build-dependencies]
+pkg-config = "0.3"

--- a/coin_cbc_sys/build.rs
+++ b/coin_cbc_sys/build.rs
@@ -1,0 +1,5 @@
+extern crate pkg_config;
+
+fn main() {
+    let _ = pkg_config::probe_library("cbc");
+}


### PR DESCRIPTION
This adds a tiny build-time dependency on pkg-config. Note that if `pkg-config` is not present, or is present but fails to locate the library or execute, nothing weird happens: the user gets the same behaviour they've had until now.

I've added a line to README to mention `pkg-config` too.

Fixes #23