### PR TITLE
Locate static cbc libs on windows via CBC_ROOT

### DIFF
--- a/coin_cbc_sys/build.rs
+++ b/coin_cbc_sys/build.rs
@@ -1,5 +1,24 @@
 extern crate pkg_config;
+use std::env;
 
 fn main() {
     let _ = pkg_config::probe_library("cbc");
+    if cfg!(windows) {
+        match env::var("CBC_ROOT") {
+            Ok(cbc_root) => {
+                println!("cargo:rustc-link-search={cbc_root}\\lib");
+                println!(r"cargo:rustc-link-lib=static=libCbcSolver");
+                println!(r"cargo:rustc-link-lib=static=libCbc");
+                println!(r"cargo:rustc-link-lib=static=libCgl");
+                println!(r"cargo:rustc-link-lib=static=libCoinUtils");
+                println!(r"cargo:rustc-link-lib=static=libClp");
+                println!(r"cargo:rustc-link-lib=static=libOsi");
+                println!(r"cargo:rustc-link-lib=static=libOsiClp");
+                ()
+            }
+            _ => {
+                println!(r"cargo:warning=CBC_ROOT environment variable not found.");
+            }
+        }
+    }
 }

--- a/coin_cbc_sys/build.rs
+++ b/coin_cbc_sys/build.rs
@@ -7,13 +7,14 @@ fn main() {
         match env::var("CBC_ROOT") {
             Ok(cbc_root) => {
                 println!("cargo:rustc-link-search={cbc_root}\\lib");
-                println!(r"cargo:rustc-link-lib=static=libCbcSolver");
-                println!(r"cargo:rustc-link-lib=static=libCbc");
-                println!(r"cargo:rustc-link-lib=static=libCgl");
-                println!(r"cargo:rustc-link-lib=static=libCoinUtils");
-                println!(r"cargo:rustc-link-lib=static=libClp");
-                println!(r"cargo:rustc-link-lib=static=libOsi");
-                println!(r"cargo:rustc-link-lib=static=libOsiClp");
+                println!(r"cargo:rustc-link-lib=static=Cbc");
+                println!(r"cargo:rustc-link-lib=static=CbcSolver");
+                println!(r"cargo:rustc-link-lib=static=Cgl");
+                println!(r"cargo:rustc-link-lib=static=Clp");
+                println!(r"cargo:rustc-link-lib=static=CoinUtils");
+                println!(r"cargo:rustc-link-lib=static=Osi");
+                println!(r"cargo:rustc-link-lib=static=OsiClp");
+                println!(r"cargo:rustc-link-lib=static=zlib");
                 ()
             }
             _ => {

--- a/coin_cbc_sys/src/lib.rs
+++ b/coin_cbc_sys/src/lib.rs
@@ -22,11 +22,7 @@ pub type cbc_callback = Option<
     ),
 >;
 
-#[cfg_attr(
-    target_family = "windows",
-    link(name = "libCbcSolver", kind = "static")
-)]
-#[cfg_attr(not(target_family = "windows"), link(name = "CbcSolver"))]
+#[link(name = "CbcSolver")]
 extern "C" {
     pub fn Cbc_newModel() -> *mut Cbc_Model;
     pub fn Cbc_deleteModel(model: *mut Cbc_Model);

--- a/coin_cbc_sys/src/lib.rs
+++ b/coin_cbc_sys/src/lib.rs
@@ -22,7 +22,11 @@ pub type cbc_callback = Option<
     ),
 >;
 
-#[link(name = "CbcSolver")]
+#[cfg_attr(
+    target_family = "windows",
+    link(name = "libCbcSolver", kind = "static")
+)]
+#[cfg_attr(not(target_family = "windows"), link(name = "CbcSolver"))]
 extern "C" {
     pub fn Cbc_newModel() -> *mut Cbc_Model;
     pub fn Cbc_deleteModel(model: *mut Cbc_Model);


### PR DESCRIPTION
This uses std::env to check for CBC_ROOT on windows family targets an use that path for the search path for cbc libraries as named in the coin-or Cbc releases for windows (mscvXX) builds and sets the link `kind="static"` for linking.

If CBC_ROOT is not found a `cargo:warning` is emitted instead of a panic so it won't interfere with any existing windows build work-arounds.