### PR TITLE
Add support for Windows cross compile

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,8 @@
+[build.env]
+passthrough = [ "CBC_ROOT" ]
+
+[target.x86_64-pc-windows-msvc]
+image = "ghcr.io/cross-rs/x86_64-pc-windows-msvc-cross:local"
+
+[target.x86_64-pc-windows-msvc.env]
+volumes = [ "CBC_ROOT" ]

--- a/coin_cbc_sys/build.rs
+++ b/coin_cbc_sys/build.rs
@@ -1,5 +1,28 @@
 extern crate pkg_config;
+use std::env;
 
 fn main() {
-    let _ = pkg_config::probe_library("cbc");
+    match env::var("CARGO_CFG_TARGET_FAMILY")
+        .as_ref()
+        .map(String::as_str)
+    {
+        Ok("unix") => {
+            let _ = pkg_config::probe_library("cbc");
+        }
+        Ok("windows") if env::var("CBC_ROOT").is_ok() => {
+            let cbc_root = env::var("CBC_ROOT").unwrap();
+            println!("cargo:rustc-link-search={cbc_root}/lib");
+            println!(r"cargo:rustc-link-lib=static=libCbc");
+            println!(r"cargo:rustc-link-lib=static=libCbcSolver");
+            println!(r"cargo:rustc-link-lib=static=libCgl");
+            println!(r"cargo:rustc-link-lib=static=libClp");
+            println!(r"cargo:rustc-link-lib=static=libCoinUtils");
+            println!(r"cargo:rustc-link-lib=static=libOsi");
+            println!(r"cargo:rustc-link-lib=static=libOsiClp");
+        }
+        Ok("windows") if env::var("CBC_ROOT").is_err() => {
+            println!(r"cargo:warning=CBC_ROOT environment variable not found.")
+        }
+        _ => println!(r"cargo:warning=Unsupported target family."),
+    }
 }

--- a/coin_cbc_sys/src/lib.rs
+++ b/coin_cbc_sys/src/lib.rs
@@ -22,7 +22,11 @@ pub type cbc_callback = Option<
     ),
 >;
 
-#[link(name = "CbcSolver")]
+#[cfg_attr(
+    target_family = "windows",
+    link(name = "libCbcSolver")
+)]
+#[cfg_attr(not(target_family = "windows"), link(name = "CbcSolver"))]
 extern "C" {
     pub fn Cbc_newModel() -> *mut Cbc_Model;
     pub fn Cbc_deleteModel(model: *mut Cbc_Model);


### PR DESCRIPTION
A continuation of the work started in https://github.com/KardinalAI/coin_cbc/pull/28.

This is essentially https://github.com/KardinalAI/coin_cbc/pull/28/commits/bf9af7293d1b3d7bb850ee66ee761ab45f5130de but with support for https://github.com/cross-rs/cross.

## Testing
1. Install [cross](https://github.com/cross-rs/cross)
1a. Install the windows MSVC target as described here: https://github.com/cross-rs/cross-toolchains
2. Download and extract a release from [here](https://github.com/coin-or/Cbc/releases) (e.g. https://github.com/coin-or/Cbc/releases/download/releases%2F2.10.10/Cbc-releases.2.10.10-w64-msvc17-md.zip)
3. `CBC_ROOT=<path to extracted Cbc library> cross build --target=x86_64-pc-windows-msvc --example knapsack`