### PR TITLE
Unwrap pkg_config result in build script

### DIFF
--- a/coin_cbc_sys/build.rs
+++ b/coin_cbc_sys/build.rs
@@ -1,5 +1,5 @@
 extern crate pkg_config;
 
 fn main() {
-    let _ = pkg_config::probe_library("cbc");
+    pkg_config::probe_library("cbc").unwrap();
 }


### PR DESCRIPTION
Currently the `build.rs` script from `coin_cbc_sys` looks like this (I've added type annotations to clarify):

```rust
use pkg_config::{Error, Library};

fn main() {
    let _: Result<Library, Error> = pkg_config::probe_library("cbc");
}
```

The failure condition of the probe is being completely ignored! This means that a failure to find the library is only reported as confusing linking errors at the end of the build process:

```
[...] = note: LINK : fatal error LNK1181: cannot open input file 'CbcSolver.lib'
```

I think the build script should be changed to `unwrap()` the `Result` instead, which would cause cargo to show this more helpful error message, much sooner during the build process:

```
   --- stderr
  thread 'main' panicked at coin_cbc_sys\build.rs:5:38:
  called `Result::unwrap()` on an `Err` value: `"pkg-config" "--libs" "--cflags" "cbc"` did not exit successfully: exit code: 1
  error: could not find system library 'cbc' required by the 'coin_cbc_sys' crate

  --- stderr
  Package clp was not found in the pkg-config search path.
  Perhaps you should add the directory containing `clp.pc'
  to the PKG_CONFIG_PATH environment variable
  Package 'clp', required by 'cbc', not found
```
